### PR TITLE
feat: Per-fact corroboration scoring + table arithmetic

### DIFF
--- a/docs/consistency-model.md
+++ b/docs/consistency-model.md
@@ -145,3 +145,57 @@ Not yet covered (requires improved preTagging):
 - Note rollforward details (PPE, intangibles, provisions)
 - Share count vs monetary amounts in equity notes
 - IC elimination figures
+
+## Corroboration Scoring
+
+Every indexed fact gets a per-fact confidence status based on how many
+independent checks corroborate it:
+
+| Status | Meaning | Criteria |
+|---|---|---|
+| **CONFIRMED** | High confidence | ≥2 independent checks pass |
+| **CORROBORATED** | Medium confidence | Exactly 1 check passes |
+| **UNCONFIRMED** | No signal | No checks testable (missing counterpart data) |
+| **CONTRADICTED** | Investigation needed | ≥1 check fails with no explaining ambiguity |
+
+### Check types that contribute to scoring
+
+1. **Ontology checks** (Pass 1): summation, disaggregation, cross-statement
+   tie, note-to-face, IC decomposition — each passing check adds one
+   corroboration signal to every fact that participated.
+
+2. **Table arithmetic** (Pass 0): for every row with `childIds` in the
+   source data, checks that `parsedValue(parent) = SUM(parsedValue(children))`
+   per VALUE column. No ontology needed — pure structural validation.
+   When a passing arithmetic check involves an indexed fact (matched by
+   `row_id`), both parent and child facts receive a `TABLE_ARITHMETIC`
+   check result.
+
+3. **Mismatch patterns** (Pass 2): explained mismatches (UNIT_SCALE,
+   GROSS_VS_NET, etc.) are informational — they don't contradict a fact
+   but they don't confirm it either.
+
+### Scoring flow
+
+```
+Pass 0: Table arithmetic (structural, no ontology)
+   ↓
+Pass 1: Ontology relationship checks
+   ↓
+Pass 2: Mismatch pattern explanation
+   ↓
+Pass 3: Context/label validation
+   ↓
+Score: aggregate all CheckResults per fact → status
+```
+
+### Corpus example
+
+```
+Fact Scores            Wienerberger    VERBUND    voestalpine
+  CONFIRMED                   32           0            28
+  CORROBORATED               186          15           174
+  UNCONFIRMED                 90         267            96
+  CONTRADICTED                12           9            46
+  Table arithmetic hits      224           0           208
+```

--- a/eval/check_consistency.py
+++ b/eval/check_consistency.py
@@ -109,6 +109,7 @@ class Fact:
     page: int = 0
     is_primary: bool = False  # from a primary statement (PNL/SFP/OCI/CFS/SOCIE)
     value_col_count: int = 0  # number of value columns in source table
+    row_id: str = ""          # rowId from table_graphs.json (for table arithmetic)
 
 
 PRIMARY_STATEMENTS = {"PNL", "SFP", "OCI", "CFS", "SOCIE"}
@@ -406,6 +407,7 @@ def index_facts(tables: list[dict], ontology_root: str = "") -> dict[tuple[str, 
                     page=page,
                     is_primary=is_primary,
                     value_col_count=len(value_columns),
+                    row_id=row.get("rowId", ""),
                 )
                 facts[(context, concept_id, period_key)].append(fact)
 
@@ -1262,6 +1264,39 @@ def check_against_expected(findings: list[Finding], expected_path: str) -> tuple
                 fails.append(f"UNEXPECTED ERROR: {finding.message}")
 
     return passes, fails
+
+
+def check_document_scored(tables: list[dict], ontology_root: str):
+    """Run all passes including Pass 0 (table arithmetic) and return per-fact scores.
+
+    Returns (findings, score_registry) where score_registry is
+    dict[(table_id, concept_id, col_idx) → FactScore].
+    """
+    from fact_scoring import build_score_registry, apply_findings_to_scores
+    from table_arithmetic import pass0_table_arithmetic, apply_table_arithmetic_to_scores
+
+    graph = build_graph(ontology_root)
+    facts = index_facts(tables, ontology_root=ontology_root)
+
+    # Build score registry from all indexed facts
+    registry = build_score_registry(facts)
+
+    # Pass 0: table arithmetic (pre-ontology)
+    arith_results = pass0_table_arithmetic(tables)
+    apply_table_arithmetic_to_scores(arith_results, registry)
+
+    # Pass 1-3: existing ontology checks
+    p1 = pass1_validate(graph, facts)
+    patterns = load_mismatch_patterns(ontology_root)
+    p2 = pass2_explain(graph, facts, patterns, p1)
+    p3 = pass3_unexplained(graph, facts, tables, p1, p2)
+
+    all_findings = p1 + p2 + p3
+
+    # Map findings to fact scores
+    apply_findings_to_scores(all_findings, facts, registry)
+
+    return all_findings, registry
 
 
 def main():

--- a/eval/fact_scoring.py
+++ b/eval/fact_scoring.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+fact_scoring.py — Per-fact corroboration scoring.
+
+Every indexed fact gets a status based on how many independent checks
+corroborate it:
+
+  CONFIRMED     — ≥2 independent checks pass
+  CORROBORATED  — exactly 1 check passes
+  UNCONFIRMED   — no checks testable
+  CONTRADICTED  — ≥1 check fails with no explaining ambiguity
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class CorroborationStatus(Enum):
+    CONFIRMED = "CONFIRMED"
+    CORROBORATED = "CORROBORATED"
+    UNCONFIRMED = "UNCONFIRMED"
+    CONTRADICTED = "CONTRADICTED"
+
+
+@dataclass
+class CheckResult:
+    """One validation check applied to a fact."""
+    check_type: str    # SUMMATION, CROSS_STATEMENT_TIE, DISAGGREGATION,
+                       # NOTE_TO_FACE, IC_DECOMPOSITION, TABLE_ARITHMETIC
+    edge_name: str     # ontology edge or "table_arith_{table_id}"
+    passed: bool
+    delta: float = 0.0
+    explained: bool = False  # True if failure is explained by ambiguity/pattern
+    detail: str = ""
+
+
+@dataclass
+class FactScore:
+    """Corroboration score for a single indexed fact."""
+    table_id: str
+    context: str
+    concept_id: str
+    period_key: str
+    col_idx: int
+    amount: float
+    label: str
+    page: int = 0
+    row_id: str = ""
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def status(self) -> CorroborationStatus:
+        if not self.checks:
+            return CorroborationStatus.UNCONFIRMED
+        passing = [c for c in self.checks if c.passed]
+        failing_unexplained = [c for c in self.checks if not c.passed and not c.explained]
+        if failing_unexplained:
+            return CorroborationStatus.CONTRADICTED
+        if len(passing) >= 2:
+            return CorroborationStatus.CONFIRMED
+        if len(passing) == 1:
+            return CorroborationStatus.CORROBORATED
+        # All checks were explained failures — not contradicted, but not confirmed
+        return CorroborationStatus.UNCONFIRMED
+
+    @property
+    def fact_key(self) -> tuple:
+        return (self.table_id, self.concept_id, self.col_idx)
+
+    def to_dict(self) -> dict:
+        d = {
+            "table_id": self.table_id,
+            "context": self.context,
+            "concept_id": self.concept_id,
+            "period_key": self.period_key,
+            "amount": self.amount,
+            "label": self.label,
+            "status": self.status.value,
+        }
+        if self.checks:
+            d["checks"] = [
+                {
+                    "type": c.check_type,
+                    "edge": c.edge_name,
+                    "passed": c.passed,
+                    "delta": c.delta,
+                }
+                for c in self.checks
+            ]
+        return d
+
+
+def build_score_registry(facts: dict) -> dict[tuple, FactScore]:
+    """Create a FactScore for every indexed fact.
+
+    Key: (table_id, concept_id, col_idx) → FactScore
+    """
+    registry: dict[tuple, FactScore] = {}
+    for (ctx, cid, pk), fact_list in facts.items():
+        for f in fact_list:
+            key = (f.table_id, f.concept_id, f.col_idx)
+            if key not in registry:
+                registry[key] = FactScore(
+                    table_id=f.table_id,
+                    context=f.context,
+                    concept_id=f.concept_id,
+                    period_key=pk,
+                    col_idx=f.col_idx,
+                    amount=f.amount,
+                    label=f.label,
+                    page=f.page,
+                    row_id=getattr(f, "row_id", ""),
+                )
+    return registry
+
+
+# Map Finding categories to check pass/fail/explained
+_PASSING_CATEGORIES = {"VALID_DISAGGREGATION", "VALID_TIE"}
+_EXPLAINED_CATEGORIES = {"EXPLAINED_MISMATCH", "UNEXPLAINED_INCONSISTENCY", "IC_LEAKAGE"}
+
+
+def apply_findings_to_scores(
+    findings: list,
+    facts: dict,
+    registry: dict[tuple, FactScore],
+) -> None:
+    """Map each Finding to the Facts it tested, append CheckResults."""
+    for finding in findings:
+        cat_val = finding.category.value
+        passed = cat_val in _PASSING_CATEGORIES
+        explained = cat_val in _EXPLAINED_CATEGORIES
+
+        # Determine check_type from edge or category
+        check_type = finding.edge_name.split("_")[0].upper() if finding.edge_name else cat_val
+        if finding.pattern_id:
+            check_type = f"PATTERN_{finding.pattern_id}"
+
+        cr = CheckResult(
+            check_type=check_type,
+            edge_name=finding.edge_name or finding.pattern_id or cat_val,
+            passed=passed,
+            delta=finding.delta or 0.0,
+            explained=explained,
+            detail=finding.message[:120] if finding.message else "",
+        )
+
+        period = finding.details.get("period", "")
+
+        # Find all facts that participated in this finding
+        for concept_id in finding.concepts:
+            if not concept_id:
+                continue
+            for (ctx, cid, pk), fact_list in facts.items():
+                if cid != concept_id:
+                    continue
+                if period and pk != period:
+                    continue
+                for f in fact_list:
+                    key = (f.table_id, f.concept_id, f.col_idx)
+                    if key in registry:
+                        # Avoid duplicate checks from same edge
+                        existing = registry[key].checks
+                        if not any(
+                            c.edge_name == cr.edge_name and c.check_type == cr.check_type
+                            for c in existing
+                        ):
+                            existing.append(cr)

--- a/eval/run_corpus.py
+++ b/eval/run_corpus.py
@@ -22,9 +22,10 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from check_consistency import (
-    check_document, index_facts, Finding, Category,
+    check_document, check_document_scored, index_facts, Finding, Category,
     PRIMARY_STATEMENTS, _match_label, _infer_table_context,
 )
+from fact_scoring import CorroborationStatus
 from relationship_graph import build_graph, EdgeType
 
 
@@ -72,8 +73,8 @@ def analyze_document(doc_path: str, ontology_root: str) -> dict:
             else:
                 fact_sources["note_or_other"] += 1
 
-    # Run checks
-    findings = check_document(tables, ontology_root)
+    # Run checks with scoring
+    findings, score_registry = check_document_scored(tables, ontology_root)
 
     # Categorize findings
     by_category = Counter()
@@ -85,20 +86,25 @@ def analyze_document(doc_path: str, ontology_root: str) -> dict:
             by_edge[f.edge_name] += 1
         finding_details.append(f.to_dict())
 
-    # Corroboration summary
-    # Count concepts that are CONFIRMED (appear in a VALID_* finding)
+    # Per-fact corroboration from score registry
+    fact_status_counts = Counter()
+    for fs in score_registry.values():
+        fact_status_counts[fs.status.value] += 1
+
+    # Table arithmetic stats
+    table_arith_count = sum(
+        1 for fs in score_registry.values()
+        if any(c.check_type == "TABLE_ARITHMETIC" for c in fs.checks)
+    )
+
+    # Concept-level summary (backward compat + overview)
     confirmed_concepts = set()
     contradicted_concepts = set()
-    for f in findings:
-        if f.category in (Category.VALID_DISAGGREGATION, Category.VALID_TIE):
-            for c in f.concepts:
-                if c:
-                    confirmed_concepts.add(c)
-        elif f.category == Category.BROKEN_RELATIONSHIP:
-            for c in f.concepts:
-                if c:
-                    contradicted_concepts.add(c)
-
+    for fs in score_registry.values():
+        if fs.status == CorroborationStatus.CONFIRMED:
+            confirmed_concepts.add(fs.concept_id)
+        elif fs.status == CorroborationStatus.CONTRADICTED:
+            contradicted_concepts.add(fs.concept_id)
     unconfirmed_concepts = unique_concepts - confirmed_concepts - contradicted_concepts
 
     return {
@@ -124,6 +130,14 @@ def analyze_document(doc_path: str, ontology_root: str) -> dict:
             "confirmed": len(confirmed_concepts),
             "contradicted": len(contradicted_concepts),
             "unconfirmed": len(unconfirmed_concepts),
+        },
+        "fact_scores": {
+            "confirmed": fact_status_counts.get("CONFIRMED", 0),
+            "corroborated": fact_status_counts.get("CORROBORATED", 0),
+            "unconfirmed": fact_status_counts.get("UNCONFIRMED", 0),
+            "contradicted": fact_status_counts.get("CONTRADICTED", 0),
+            "total": len(score_registry),
+            "table_arithmetic": table_arith_count,
         },
         "findings": finding_details,
     }
@@ -158,9 +172,29 @@ def print_comparison(results: list[dict]):
             print(f" {r[key]:>15,d}", end="")
         print()
 
-    # Corroboration
+    # Per-fact corroboration scores
     print()
-    print(f"{'Corroboration':<35s}", end="")
+    print(f"{'Fact Scores':<35s}", end="")
+    for n in names:
+        print(f" {n:>15s}", end="")
+    print()
+    print("─" * (35 + 16 * len(names)))
+    for label, key in [
+        ("CONFIRMED (≥2 checks)", "confirmed"),
+        ("CORROBORATED (1 check)", "corroborated"),
+        ("UNCONFIRMED (no checks)", "unconfirmed"),
+        ("CONTRADICTED (failed)", "contradicted"),
+        ("Total scored facts", "total"),
+        ("Table arithmetic hits", "table_arithmetic"),
+    ]:
+        print(f"  {label:<33s}", end="")
+        for r in results:
+            print(f" {r.get('fact_scores', {}).get(key, 0):>15,d}", end="")
+        print()
+
+    # Concept-level summary
+    print()
+    print(f"{'Concept Summary':<35s}", end="")
     for n in names:
         print(f" {n:>15s}", end="")
     print()

--- a/eval/table_arithmetic.py
+++ b/eval/table_arithmetic.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+table_arithmetic.py — Pass 0: same-table structural validation.
+
+For every row with childIds, checks that parsedValue(parent) =
+SUM(parsedValue(children)) per VALUE column. No ontology needed —
+pure structural validation of the parsed data.
+
+When a passing check involves an indexed fact (matched by row_id),
+both the parent and child facts receive a TABLE_ARITHMETIC CheckResult.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class TableArithmeticResult:
+    """Result of a same-table parent/child summation check."""
+    table_id: str
+    parent_row_id: str
+    parent_row_type: str   # TOTAL_EXPLICIT or TOTAL_IMPLICIT
+    child_row_ids: list[str]
+    col_idx: int
+    expected_sum: float    # SUM(child parsedValues)
+    actual_total: float    # parent parsedValue
+    passed: bool
+    delta: float
+
+
+def _get_value_col_indices(table: dict) -> list[int]:
+    """Get sorted VALUE column indices."""
+    return sorted(
+        c["colIdx"]
+        for c in table.get("columns", [])
+        if c.get("role") == "VALUE"
+    )
+
+
+def _get_cell_value(row: dict, col_idx: int) -> Optional[float]:
+    """Get parsedValue for a specific column in a row."""
+    for cell in row.get("cells", []):
+        if cell.get("colIdx") == col_idx and cell.get("parsedValue") is not None:
+            return cell["parsedValue"]
+    return None
+
+
+def pass0_table_arithmetic(
+    tables: list[dict],
+    tolerance: float = 0.5,
+) -> list[TableArithmeticResult]:
+    """Validate parent/child summations within each table.
+
+    For every row with childIds, checks each VALUE column:
+      parent.parsedValue == SUM(child.parsedValue)
+
+    Both TOTAL_EXPLICIT and TOTAL_IMPLICIT are checked. TOTAL_EXPLICIT
+    validates source data; TOTAL_IMPLICIT validates parser computation
+    but still confirms child values are internally consistent.
+    """
+    results = []
+
+    for table in tables:
+        table_id = table["tableId"]
+        rows_by_id = {r["rowId"]: r for r in table.get("rows", [])}
+        value_cols = _get_value_col_indices(table)
+
+        for row in table.get("rows", []):
+            child_ids = row.get("childIds", [])
+            if not child_ids:
+                continue
+
+            row_type = row.get("rowType", "DATA")
+            children = [rows_by_id[cid] for cid in child_ids if cid in rows_by_id]
+            if not children:
+                continue
+
+            for col_idx in value_cols:
+                total_val = _get_cell_value(row, col_idx)
+                if total_val is None:
+                    continue
+
+                child_vals = []
+                for child in children:
+                    cv = _get_cell_value(child, col_idx)
+                    if cv is not None:
+                        child_vals.append(cv)
+
+                if not child_vals:
+                    continue
+
+                child_sum = sum(child_vals)
+                delta = abs(total_val - child_sum)
+                # Tolerance: absolute tolerance OR 0.1% of the total (for rounding in Mio tables)
+                effective_tolerance = max(tolerance, abs(total_val) * 0.001) if total_val != 0 else tolerance
+                passed = delta <= effective_tolerance
+
+                results.append(TableArithmeticResult(
+                    table_id=table_id,
+                    parent_row_id=row["rowId"],
+                    parent_row_type=row_type,
+                    child_row_ids=child_ids,
+                    col_idx=col_idx,
+                    expected_sum=child_sum,
+                    actual_total=total_val,
+                    passed=passed,
+                    delta=delta,
+                ))
+
+    return results
+
+
+def apply_table_arithmetic_to_scores(
+    results: list[TableArithmeticResult],
+    registry: dict,
+) -> int:
+    """Link passing arithmetic checks to indexed facts via row_id.
+
+    For each passing result, finds FactScores whose row_id matches
+    the parent or any child row, and adds a TABLE_ARITHMETIC CheckResult.
+
+    Returns the number of facts that received a check.
+    """
+    from fact_scoring import CheckResult
+
+    # Build row_id → list of FactScore keys for fast lookup
+    row_to_keys: dict[str, list[tuple]] = {}
+    for key, fs in registry.items():
+        if fs.row_id:
+            row_to_keys.setdefault(fs.row_id, []).append(key)
+
+    scored_count = 0
+
+    for result in results:
+        cr = CheckResult(
+            check_type="TABLE_ARITHMETIC",
+            edge_name=f"table_arith_{result.table_id}",
+            passed=result.passed,
+            delta=result.delta,
+            detail=f"{'PASS' if result.passed else 'FAIL'}: parent {result.parent_row_id} ({result.parent_row_type}), {len(result.child_row_ids)} children, col {result.col_idx}",
+        )
+
+        # Apply to parent fact
+        all_row_ids = [result.parent_row_id] + result.child_row_ids
+        for row_id in all_row_ids:
+            for key in row_to_keys.get(row_id, []):
+                fs = registry[key]
+                # Only add if same column and no duplicate
+                if fs.col_idx == result.col_idx:
+                    if not any(
+                        c.check_type == "TABLE_ARITHMETIC" and c.edge_name == cr.edge_name
+                        for c in fs.checks
+                    ):
+                        fs.checks.append(cr)
+                        scored_count += 1
+
+    return scored_count


### PR DESCRIPTION
## Summary

Flips the output model from "find errors" to "score every tag". Every indexed fact gets a corroboration status based on how many independent checks validate it.

### New: Pass 0 — Table arithmetic
Validates `parsedValue(parent) = SUM(parsedValue(children))` for every row with `childIds`. No ontology needed — pure structural validation. Tolerance adapts to value scale (0.1% for Mio-scale rounding).

### Per-fact scoring
Each fact accumulates `CheckResult` entries from Pass 0 (table arithmetic) and Pass 1-3 (ontology checks). Final status:
- **CONFIRMED** (≥2 checks pass) — high confidence
- **CORROBORATED** (1 check) — medium confidence
- **UNCONFIRMED** (0 testable) — no signal
- **CONTRADICTED** (unexplained failure) — investigate

### Corpus results

| | Wienerberger | VERBUND | voestalpine |
|---|---|---|---|
| CONFIRMED | 32 | 0 | 28 |
| CORROBORATED | 186 | 15 | 174 |
| UNCONFIRMED | 90 | 267 | 96 |
| CONTRADICTED | 12 | 9 | 46 |
| Table arithmetic hits | 224 | 0 | 208 |

voestalpine went from 0 confirmed to 28 — entirely from table arithmetic.

## Test plan
- [x] Wienerberger fixture: 5/5 pass
- [x] Findings unchanged from Milestone 1
- [x] Table arithmetic validates across Wienerberger (178 rows) and voestalpine (283 rows)

Generated with [Claude Code](https://claude.com/claude-code)