### PR TITLE
Rename IC_LEAKAGE to DECOMPOSITION_RESIDUAL

### DIFF
--- a/docs/consistency-model.md
+++ b/docs/consistency-model.md
@@ -37,7 +37,7 @@ Uses the ontology graph (counterparts.yaml + concept metadata) to check:
 | **CROSS_STATEMENT_TIE** | `cross_statement_ties` | trigger amount = requires amount |
 | **IC_DECOMPOSITION** | `ic_decomposition` | face = external + IC |
 
-Results: `VALID_DISAGGREGATION`, `VALID_TIE`, `BROKEN_RELATIONSHIP`, `IC_LEAKAGE`
+Results: `VALID_DISAGGREGATION`, `VALID_TIE`, `BROKEN_RELATIONSHIP`, `DECOMPOSITION_RESIDUAL`
 
 **Same-table preference**: When a concept appears in multiple tables
 (e.g., 10-year overview vs primary statement), the engine prefers the
@@ -84,7 +84,7 @@ Result: `UNEXPLAINED_INCONSISTENCY`
 | `VALID_DISAGGREGATION` | Declared relationship holds | None |
 | `VALID_TIE` | Cross-statement tie holds | None |
 | `BROKEN_RELATIONSHIP` | Declared relationship fails | ERROR — investigate |
-| `IC_LEAKAGE` | face ≠ external + IC | WARNING — IC not eliminated |
+| `DECOMPOSITION_RESIDUAL` | face ≠ external + IC | WARNING — unexplained residual |
 | `EXPLAINED_MISMATCH` | Known pattern explains difference | INFO — document |
 | `UNEXPLAINED_INCONSISTENCY` | No relationship, no pattern | WARNING — investigate |
 

--- a/eval/catalogue.yaml
+++ b/eval/catalogue.yaml
@@ -21,7 +21,7 @@ catalogue:
         description: "IC decomposition valid: face = external + IC for both 2024 (IC=0) and 2023 (IC=909)"
 
       - id: WBI-003
-        category: IC_LEAKAGE
+        category: DECOMPOSITION_RESIDUAL
         edge: revenue_by_segment
         description: "Revenue IC residual 909 TEUR in 2023 comparative"
         root_cause: "Intercompany revenue not fully eliminated in 2023 consolidation"

--- a/eval/check_consistency.py
+++ b/eval/check_consistency.py
@@ -5,7 +5,7 @@ check_consistency.py — Three-pass structural consistency checker.
 Replaces check_cross_reference.py with ontology-driven validation.
 
 Pass 1: Validate DECLARED relationships (counterparts.yaml + concept metadata)
-  → VALID_DISAGGREGATION, VALID_TIE, BROKEN_RELATIONSHIP, IC_LEAKAGE
+  → VALID_DISAGGREGATION, VALID_TIE, BROKEN_RELATIONSHIP, DECOMPOSITION_RESIDUAL
 
 Pass 2: Explain KNOWN mismatch patterns (mismatch_patterns.yaml)
   → EXPLAINED_MISMATCH with pattern ID
@@ -47,7 +47,7 @@ class Category(Enum):
     BROKEN_RELATIONSHIP = "BROKEN_RELATIONSHIP"
     EXPLAINED_MISMATCH = "EXPLAINED_MISMATCH"
     UNEXPLAINED_INCONSISTENCY = "UNEXPLAINED_INCONSISTENCY"
-    IC_LEAKAGE = "IC_LEAKAGE"
+    DECOMPOSITION_RESIDUAL = "DECOMPOSITION_RESIDUAL"
 
 
 @dataclass
@@ -575,7 +575,7 @@ def _triage_residual(
             for amb in edge.ambiguities:
                 if amb.get("id") == amb_id:
                     return {
-                        "category": Category.IC_LEAKAGE,
+                        "category": Category.DECOMPOSITION_RESIDUAL,
                         "severity": amb.get("severity", "WARNING"),
                         "message": f"IC confirmed: {{face}}={{face_val:,.0f}}, external={{detail_sum:,.0f}}, IC={{residual:,.0f}} (matches tagged {confirm_cid}) [{{pk}}]",
                         "extra_concepts": [confirm_cid],
@@ -595,7 +595,7 @@ def _triage_residual(
     possible = [amb.get("id") for amb in edge.ambiguities if amb.get("id") != "ROUNDING"]
 
     return {
-        "category": Category.IC_LEAKAGE,
+        "category": Category.DECOMPOSITION_RESIDUAL,
         "severity": "INFO",
         "message": f"Disaggregation residual: {{face}}={{face_val:,.0f}}, SUM={{detail_sum:,.0f}}, Δ={{residual:,.0f}} — possible: {', '.join(possible) or 'unknown cause'} [{{pk}}]",
         "extra_details": {"ambiguity": "UNRESOLVED", "possible_causes": possible},
@@ -930,14 +930,14 @@ def pass1_validate(graph: OntologyGraph, facts: dict) -> list[Finding]:
                 ))
             elif ic_amount == 0 and delta > TOLERANCE:
                 findings.append(Finding(
-                    category=Category.IC_LEAKAGE,
+                    category=Category.DECOMPOSITION_RESIDUAL,
                     edge_name=edge.name,
                     severity="WARNING",
                     expected=face_val,
                     actual=ext_val,
                     delta=delta,
                     concepts=[edge.ic_face_concept, edge.ic_external_concept or ""],
-                    message=f"IC LEAKAGE: {edge.ic_face_concept}={face_val:,.0f}, external={ext_val:,.0f}, IC not tagged, Δ={delta:,.0f} [{pk}]",
+                    message=f"Decomposition residual: {edge.ic_face_concept}={face_val:,.0f}, external={ext_val:,.0f}, IC not tagged, Δ={delta:,.0f} [{pk}]",
                     details={"period": pk, "ic_missing": True},
                 ))
             else:
@@ -1415,7 +1415,7 @@ def main():
         Category.VALID_DISAGGREGATION,
         Category.VALID_TIE,
         Category.BROKEN_RELATIONSHIP,
-        Category.IC_LEAKAGE,
+        Category.DECOMPOSITION_RESIDUAL,
         Category.EXPLAINED_MISMATCH,
         Category.UNEXPLAINED_INCONSISTENCY,
     ]
@@ -1423,7 +1423,7 @@ def main():
         Category.VALID_DISAGGREGATION: "✅",
         Category.VALID_TIE: "✅",
         Category.BROKEN_RELATIONSHIP: "❌",
-        Category.IC_LEAKAGE: "⚠️",
+        Category.DECOMPOSITION_RESIDUAL: "⚠️",
         Category.EXPLAINED_MISMATCH: "ℹ️",
         Category.UNEXPLAINED_INCONSISTENCY: "❓",
     }
@@ -1449,7 +1449,7 @@ def main():
             print(f"  {icon} {cat.value}: {count}")
 
     errors = len(by_category.get(Category.BROKEN_RELATIONSHIP.value, []))
-    ic_leak = len(by_category.get(Category.IC_LEAKAGE.value, []))
+    ic_leak = len(by_category.get(Category.DECOMPOSITION_RESIDUAL.value, []))
     return 1 if errors > 0 else 0
 
 

--- a/eval/check_cross_reference.py
+++ b/eval/check_cross_reference.py
@@ -147,7 +147,7 @@ def check_revenue_consistency(tables):
             if best_match and best_delta > 0:
                 ic_val = segment_ic.get(best_match[0], 0)
                 issues.append({
-                    'check': 'REVENUE_IC_LEAKAGE',
+                    'check': 'REVENUE_DECOMPOSITION_RESIDUAL',
                     'severity': 'WARNING' if best_delta < abs(pnl_val) * 0.01 else 'ERROR',
                     'pnl_face_revenue': pnl_val,
                     'segment_external_revenue': best_match[1],

--- a/eval/fact_scoring.py
+++ b/eval/fact_scoring.py
@@ -117,7 +117,7 @@ def build_score_registry(facts: dict) -> dict[tuple, FactScore]:
 
 # Map Finding categories to check pass/fail/explained
 _PASSING_CATEGORIES = {"VALID_DISAGGREGATION", "VALID_TIE"}
-_EXPLAINED_CATEGORIES = {"EXPLAINED_MISMATCH", "UNEXPLAINED_INCONSISTENCY", "IC_LEAKAGE"}
+_EXPLAINED_CATEGORIES = {"EXPLAINED_MISMATCH", "UNEXPLAINED_INCONSISTENCY", "DECOMPOSITION_RESIDUAL"}
 
 
 def apply_findings_to_scores(

--- a/eval/fixtures/wienerberger_2024/expected_violations.json
+++ b/eval/fixtures/wienerberger_2024/expected_violations.json
@@ -14,7 +14,7 @@
       "description": "IC decomposition valid: external + IC = face (both 2024 and 2023)"
     },
     {
-      "category": "IC_LEAKAGE",
+      "category": "DECOMPOSITION_RESIDUAL",
       "edge_name": "revenue_by_segment",
       "description": "Revenue IC residual 909 TEUR in 2023 comparative — intercompany revenue not fully eliminated"
     },

--- a/eval/run_corpus.py
+++ b/eval/run_corpus.py
@@ -218,7 +218,7 @@ def print_comparison(results: list[dict]):
         "VALID_DISAGGREGATION": "✅",
         "VALID_TIE": "✅",
         "BROKEN_RELATIONSHIP": "❌",
-        "IC_LEAKAGE": "⚠️",
+        "DECOMPOSITION_RESIDUAL": "⚠️",
         "EXPLAINED_MISMATCH": "ℹ️",
         "UNEXPLAINED_INCONSISTENCY": "❓",
     }


### PR DESCRIPTION
## Summary

- Renames the `IC_LEAKAGE` finding category to `DECOMPOSITION_RESIDUAL` across all 7 affected files
- Updates log messages and documentation to use cause-neutral language
- IC leakage remains a documented ambiguity ID (`IC_NOT_ELIMINATED`) within the check

The IC decomposition check (`face = external + IC`) catches any unexplained residual — restatements, segment reclassifications, missing tags, rounding — not only IC elimination failures. The old name presupposed the cause; the new name describes the detection.

Closes #13

## Test plan

- [ ] Verify `grep -r IC_LEAKAGE` returns no hits
- [ ] Run `check_consistency.py` against Wienerberger fixture — findings should match `expected_violations.json` with the updated category name
- [ ] Confirm `run_corpus.py` summary output shows `DECOMPOSITION_RESIDUAL` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)