### PR TITLE
feat: add Machine Tag page (#51)

### DIFF
--- a/eval/machine_tag_runner.py
+++ b/eval/machine_tag_runner.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+machine_tag_runner.py — Run a single tagging model across multiple documents.
+
+Invoked as a subprocess by the explorer server. Runs one of three tagging
+models (pretag, structural, llm) on each document, writes results to an
+output directory, and optionally appends to the tag log and/or voting system.
+
+Usage:
+    python3 eval/machine_tag_runner.py \
+        --model pretag \
+        --documents amag_2024 evn_2024 \
+        --output-dir eval/machine_tag_runs/30032026MT001 \
+        [--dry-run] [--verbose] \
+        [--write-tag-log] [--write-voting]
+"""
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Add eval dir to path for sibling imports
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+sys.path.insert(0, str(REPO_ROOT))
+
+FIXTURES_DIR = REPO_ROOT / "eval" / "fixtures"
+
+# ── Tag log / voting helpers ──────────────────────────────────────────────
+
+TAG_LOG_PATH = FIXTURES_DIR / ".tag_log.jsonl"
+
+
+def _append_tag_log_file(entry: dict):
+    """Append a tag-log entry to the file-based JSONL log."""
+    with open(TAG_LOG_PATH, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _get_supabase_queries():
+    """Lazily import explorer queries module (needs SUPABASE env vars)."""
+    try:
+        sys.path.insert(0, str(REPO_ROOT / "explorer"))
+        import queries as Q
+        # Test that supabase is configured
+        Q.get_supabase()
+        return Q
+    except Exception:
+        return None
+
+
+def _append_tag_log(entry: dict, Q):
+    """Write a tag-log entry to both file and Supabase (if available)."""
+    _append_tag_log_file(entry)
+    if Q:
+        try:
+            Q.append_tag_log(entry)
+        except Exception:
+            pass  # Supabase table may not exist yet
+
+
+def _cast_vote(vote: dict, Q):
+    """Cast a vote via Supabase queries (no HTTP, no auth)."""
+    if Q:
+        try:
+            Q.cast_tag_vote(vote)
+        except Exception as e:
+            print(f"  [vote] failed: {e}", file=sys.stderr)
+
+
+# ── Per-document runner ───────────────────────────────────────────────────
+
+def _run_pretag(tg_path: str, dry_run: bool, verbose: bool) -> list[dict]:
+    """Run pretag_all on a single document. Returns list of new tags."""
+    from pretag_all import pretag_document
+    return pretag_document(tg_path, dry_run=dry_run) or []
+
+
+def _run_structural(tg_path: str, dry_run: bool, verbose: bool) -> list[dict]:
+    """Run structural inference on a single document. Returns list of inferred tags."""
+    from structural_inference import run_structural_inference
+    return run_structural_inference(tg_path, dry_run=dry_run, verbose=verbose) or []
+
+
+def _run_llm(tg_path: str, dry_run: bool, verbose: bool) -> list[dict]:
+    """Run LLM tagger on a single document. Returns list of LLM tags."""
+    from llm_tagger import tag_document
+    return tag_document(tg_path, dry_run=dry_run, verbose=verbose) or []
+
+
+MODEL_RUNNERS = {
+    "pretag": _run_pretag,
+    "structural": _run_structural,
+    "llm": _run_llm,
+}
+
+SOURCE_MAP = {
+    "pretag": "machine:pretag",
+    "structural": "machine:structural",
+    "llm": "machine:llm",
+}
+
+
+def run_document(
+    doc_id: str,
+    model: str,
+    output_dir: Path,
+    *,
+    dry_run: bool = False,
+    verbose: bool = False,
+    write_tag_log: bool = False,
+    write_voting: bool = False,
+    Q=None,
+) -> dict:
+    """Process a single document with the chosen model. Returns result dict."""
+    tg_path = str(FIXTURES_DIR / doc_id / "table_graphs.json")
+    if not os.path.exists(tg_path):
+        return {"document_id": doc_id, "error": f"table_graphs.json not found", "rows_tagged": 0}
+
+    runner = MODEL_RUNNERS[model]
+    source = SOURCE_MAP[model]
+
+    try:
+        tags = runner(tg_path, dry_run, verbose)
+        if tags is None:
+            tags = []
+    except Exception as e:
+        traceback.print_exc()
+        return {"document_id": doc_id, "error": str(e), "rows_tagged": 0}
+
+    rows_tagged = len(tags)
+    tag_log_entries = 0
+    votes_cast = 0
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Write to tag log
+    if write_tag_log and not dry_run:
+        for tag in tags:
+            entry = {
+                "timestamp": now,
+                "user_email": "machine",
+                "doc_id": doc_id,
+                "page_no": tag.get("page_no"),
+                "action": "add",
+                "element_type": tag.get("concept_id") or tag.get("preTagged"),
+                "old_type": None,
+                "source": source,
+            }
+            _append_tag_log(entry, Q)
+            tag_log_entries += 1
+
+    # Cast votes
+    if write_voting and not dry_run and Q:
+        for tag in tags:
+            target_id = tag.get("row_id")
+            concept = tag.get("concept_id") or tag.get("preTagged")
+            if not target_id or not concept:
+                continue
+            vote = {
+                "dimension": "row_concept",
+                "target_id": target_id,
+                "action": "tag",
+                "value": concept,
+                "confidence": tag.get("confidence", 0.8),
+                "source": source,
+                "comment": f"Machine tag run ({model})",
+            }
+            _cast_vote(vote, Q)
+            votes_cast += 1
+
+    result = {
+        "document_id": doc_id,
+        "rows_tagged": rows_tagged,
+        "tag_log_entries": tag_log_entries,
+        "votes_cast": votes_cast,
+    }
+
+    # Write per-doc result
+    doc_dir = output_dir / doc_id
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    with open(doc_dir / "result.json", "w") as f:
+        json.dump(result, f, indent=2)
+
+    return result
+
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a tagging model across documents")
+    parser.add_argument("--model", required=True, choices=["pretag", "structural", "llm"])
+    parser.add_argument("--documents", nargs="+", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument("--write-tag-log", action="store_true")
+    parser.add_argument("--write-voting", action="store_true")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Lazy-load Supabase queries if voting is needed
+    Q = _get_supabase_queries() if (args.write_tag_log or args.write_voting) else None
+
+    total_tagged = 0
+    total_log = 0
+    total_votes = 0
+    docs_processed = 0
+
+    print(f"Machine Tag: model={args.model}, docs={len(args.documents)}, "
+          f"tag_log={args.write_tag_log}, voting={args.write_voting}, dry_run={args.dry_run}")
+
+    for i, doc_id in enumerate(args.documents, 1):
+        print(f"\n[{i}/{len(args.documents)}] {doc_id}")
+        result = run_document(
+            doc_id,
+            args.model,
+            output_dir,
+            dry_run=args.dry_run,
+            verbose=args.verbose,
+            write_tag_log=args.write_tag_log,
+            write_voting=args.write_voting,
+            Q=Q,
+        )
+        if result.get("error"):
+            print(f"  ERROR: {result['error']}")
+        else:
+            print(f"  rows_tagged={result['rows_tagged']} "
+                  f"tag_log={result['tag_log_entries']} votes={result['votes_cast']}")
+            docs_processed += 1
+        total_tagged += result.get("rows_tagged", 0)
+        total_log += result.get("tag_log_entries", 0)
+        total_votes += result.get("votes_cast", 0)
+
+    # Write summary
+    summary = {
+        "model": args.model,
+        "docs_processed": docs_processed,
+        "docs_total": len(args.documents),
+        "rows_tagged": total_tagged,
+        "tag_log_entries": total_log,
+        "votes_cast": total_votes,
+        "dry_run": args.dry_run,
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    with open(output_dir / "summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(f"\nDone: {docs_processed}/{len(args.documents)} docs, "
+          f"{total_tagged} rows tagged, {total_log} log entries, {total_votes} votes")
+
+
+if __name__ == "__main__":
+    main()

--- a/explorer/frontend/src/App.jsx
+++ b/explorer/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import OntologyPage from './components/OntologyPage.jsx'
 import GroundTruthPage from './components/GroundTruthPage.jsx'
 import DocumentEdgesPage from './components/DocumentEdgesPage.jsx'
 import TrainingPage from './components/TrainingPage.jsx'
+import MachineTagPage from './components/MachineTagPage.jsx'
 import PdfPane from './components/PdfPane.jsx'
 import SearchBar from './components/SearchBar.jsx'
 import { useStats, useDocuments, useConcept, useConceptPages } from './api.js'
@@ -112,6 +113,9 @@ function PageContent() {
 
     case 'training':
       return <TrainingPage />
+
+    case 'machine-tag':
+      return <MachineTagPage />
 
     default:
       return (

--- a/explorer/frontend/src/api.js
+++ b/explorer/frontend/src/api.js
@@ -37,6 +37,22 @@ export function useStats() {
   })
 }
 
+export function useCorpusHealth() {
+  return useQuery({
+    queryKey: ['corpus-health'],
+    queryFn: () => fetchJSON('/api/dashboard/corpus-health'),
+    staleTime: 5 * 60_000,
+  })
+}
+
+export function useTagActivity() {
+  return useQuery({
+    queryKey: ['tag-activity'],
+    queryFn: () => fetchJSON('/api/dashboard/tag-activity'),
+    staleTime: 60_000,
+  })
+}
+
 export function useDocuments() {
   return useQuery({
     queryKey: ['documents'],
@@ -629,5 +645,57 @@ export function useCancelRun() {
   return useMutation({
     mutationFn: (runId) => fetchJSON(`/api/runs/${runId}/cancel`, { method: 'POST' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['runs'] }),
+  })
+}
+
+// ── Machine Tag Runs ──────────────────────────────────────────
+
+export function useMachineTagRuns() {
+  return useQuery({
+    queryKey: ['mt-runs'],
+    queryFn: () => fetchJSON('/api/machine-tag/runs').then(d => d.runs || []),
+    staleTime: 10_000,
+  })
+}
+
+export function useMachineTagRun(runId) {
+  return useQuery({
+    queryKey: ['mt-run', runId],
+    queryFn: () => fetchJSON(`/api/machine-tag/runs/${runId}`),
+    enabled: !!runId,
+    staleTime: 3_000,
+    refetchInterval: (query) => {
+      const data = query.state.data
+      return data?.status === 'running' ? 3000 : false
+    },
+  })
+}
+
+export function useMachineTagRunResults(runId) {
+  return useQuery({
+    queryKey: ['mt-run-results', runId],
+    queryFn: () => fetchJSON(`/api/machine-tag/runs/${runId}/results`).then(d => d.results || []),
+    enabled: !!runId,
+    staleTime: 5_000,
+  })
+}
+
+export function useCreateMachineTagRun() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (body) => fetchJSON('/api/machine-tag/runs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['mt-runs'] }),
+  })
+}
+
+export function useCancelMachineTagRun() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (runId) => fetchJSON(`/api/machine-tag/runs/${runId}/cancel`, { method: 'POST' }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['mt-runs'] }),
   })
 }

--- a/explorer/frontend/src/components/AppSidebar.jsx
+++ b/explorer/frontend/src/components/AppSidebar.jsx
@@ -1,7 +1,7 @@
 import {
   LayoutDashboard, FileText, Layers, Network, GitBranch,
   ShieldCheck, ClipboardCheck, BookOpen, History, FlaskConical,
-  Sun, Moon, LogOut, ChevronUp, Settings
+  Sun, Moon, LogOut, ChevronUp, Settings, Bot,
 } from 'lucide-react'
 import { useNavigation } from '@/lib/hooks/useNavigation.jsx'
 import { useTheme } from '@/lib/hooks/useTheme.jsx'
@@ -37,6 +37,7 @@ const navPlatform = [
 
 const navPipeline = [
   { id: 'training', title: 'Training', icon: FlaskConical },
+  { id: 'machine-tag', title: 'Machine Tag', icon: Bot },
 ]
 
 const navQuality = [

--- a/explorer/frontend/src/components/MachineTagPage.jsx
+++ b/explorer/frontend/src/components/MachineTagPage.jsx
@@ -1,0 +1,544 @@
+import React, { useState, useMemo } from 'react'
+import {
+  useMachineTagRuns, useMachineTagRun, useMachineTagRunResults,
+  useCreateMachineTagRun, useCancelMachineTagRun,
+  useDocuments, useGTSets,
+} from '../api.js'
+import { Badge } from './ui/badge.jsx'
+import { Button } from './ui/button.jsx'
+import { Input } from './ui/input.jsx'
+import { Progress } from './ui/progress.jsx'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card.jsx'
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from './ui/select.jsx'
+import {
+  Table, TableHeader, TableBody, TableRow, TableHead, TableCell,
+} from './ui/table.jsx'
+import {
+  Play, Square, Plus, ArrowLeft, CheckCircle, XCircle,
+  Clock, Loader2, Bot,
+} from 'lucide-react'
+
+// ── Status helpers ────────────────────────────────────────
+
+const STATUS_CONFIG = {
+  pending: { label: 'Pending', color: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400', icon: Clock },
+  running: { label: 'Running', color: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400', icon: Loader2 },
+  completed: { label: 'Completed', color: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400', icon: CheckCircle },
+  failed: { label: 'Failed', color: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400', icon: XCircle },
+  cancelled: { label: 'Cancelled', color: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400', icon: Square },
+}
+
+function StatusBadge({ status }) {
+  const cfg = STATUS_CONFIG[status] || STATUS_CONFIG.pending
+  const Icon = cfg.icon
+  return (
+    <Badge variant="outline" className={`text-[10px] gap-1 ${cfg.color}`}>
+      <Icon className={`size-3 ${status === 'running' ? 'animate-spin' : ''}`} />
+      {cfg.label}
+    </Badge>
+  )
+}
+
+function formatDuration(startedAt, completedAt) {
+  if (!startedAt) return '\u2013'
+  const start = new Date(startedAt)
+  const end = completedAt ? new Date(completedAt) : new Date()
+  const seconds = Math.round((end - start) / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const mins = Math.floor(seconds / 60)
+  const secs = seconds % 60
+  return `${mins}m ${secs.toString().padStart(2, '0')}s`
+}
+
+const MODEL_LABELS = {
+  pretag: 'Pretag (label match)',
+  structural: 'Structural inference',
+  llm: 'LLM (Claude Sonnet)',
+}
+
+// ── Run List View ─────────────────────────────────────────
+
+function RunListView({ onSelect, onNewRun }) {
+  const { data: runs = [], isLoading } = useMachineTagRuns()
+
+  if (isLoading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading runs...</div>
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-6 h-full overflow-y-auto">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Machine Tag Runs</h1>
+          <p className="text-sm text-muted-foreground">Run individual tagging models against datasets</p>
+        </div>
+        <Button onClick={onNewRun}>
+          <Plus className="size-4 mr-1.5" />
+          New Run
+        </Button>
+      </div>
+
+      {runs.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <Bot className="size-10 mb-3" />
+          <p className="text-sm">No machine tag runs yet</p>
+          <Button variant="outline" className="mt-3" onClick={onNewRun}>
+            Start your first run
+          </Button>
+        </div>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Run ID</TableHead>
+                <TableHead>Model</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Documents</TableHead>
+                <TableHead>Progress</TableHead>
+                <TableHead>Duration</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {runs.map(run => {
+                const progress = run.progress || {}
+                const pct = progress.docs_total
+                  ? Math.round((progress.docs_completed / progress.docs_total) * 100)
+                  : 0
+                return (
+                  <TableRow
+                    key={run.run_id}
+                    className="cursor-pointer"
+                    onClick={() => onSelect(run.run_id)}
+                  >
+                    <TableCell className="font-mono text-sm">{run.run_id}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="text-[10px]">
+                        {MODEL_LABELS[run.config?.model] || run.config?.model}
+                      </Badge>
+                    </TableCell>
+                    <TableCell><StatusBadge status={run.status} /></TableCell>
+                    <TableCell className="text-sm">
+                      {progress.docs_completed ?? 0}/{progress.docs_total ?? '?'}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2 min-w-24">
+                        <Progress value={pct} className="h-1.5 flex-1" />
+                        <span className="text-xs text-muted-foreground w-8">{pct}%</span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {formatDuration(run.started_at, run.completed_at)}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {run.created_at ? new Date(run.created_at).toLocaleDateString() : '\u2013'}
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── New Run Setup View ────────────────────────────────────
+
+function NewRunView({ onBack, onCreated }) {
+  const { data: documents = [] } = useDocuments()
+  const { data: gtSets = [] } = useGTSets()
+  const createRun = useCreateMachineTagRun()
+
+  const [model, setModel] = useState('pretag')
+  const [docMode, setDocMode] = useState('all')
+  const [selectedDocs, setSelectedDocs] = useState([])
+  const [gtSetId, setGtSetId] = useState('')
+  const [docFilter, setDocFilter] = useState('')
+  const [dryRun, setDryRun] = useState(false)
+  const [verbose, setVerbose] = useState(false)
+
+  // Output destinations
+  const [writeTagLog, setWriteTagLog] = useState(true)
+  const [writeVoting, setWriteVoting] = useState(false)
+
+  const filteredDocs = useMemo(() => {
+    const q = docFilter.toLowerCase()
+    return documents.filter(d => !q || d.id.toLowerCase().includes(q))
+  }, [documents, docFilter])
+
+  const toggleDoc = (docId) => {
+    setSelectedDocs(prev =>
+      prev.includes(docId) ? prev.filter(d => d !== docId) : [...prev, docId]
+    )
+  }
+
+  const resolvedDocs = docMode === 'all'
+    ? documents.map(d => d.id)
+    : docMode === 'select'
+    ? selectedDocs
+    : (() => {
+        const set = gtSets.find(s => s.id === gtSetId)
+        return set?.doc_ids || []
+      })()
+
+  const handleStart = () => {
+    createRun.mutate({
+      model,
+      documents: resolvedDocs,
+      config: {
+        dry_run: dryRun,
+        verbose,
+        write_tag_log: writeTagLog,
+        write_voting: writeVoting,
+      },
+    }, {
+      onSuccess: (data) => {
+        onCreated(data.run?.run_id)
+      },
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6 h-full overflow-y-auto max-w-3xl">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="sm" onClick={onBack}>
+            <ArrowLeft className="size-4" />
+          </Button>
+          <h1 className="text-xl font-semibold">Configure Machine Tag Run</h1>
+        </div>
+        <p className="text-sm text-muted-foreground ml-11">
+          Run a single tagging model against a dataset. Tags are written to table_graphs.json
+          (native tagger behavior). Optionally send results to the tag log and/or voting system.
+        </p>
+      </div>
+
+      {/* Model Selection */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">Tagging Model</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-4">
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input type="radio" checked={model === 'pretag'} onChange={() => setModel('pretag')} />
+            Pretag (label match)
+          </label>
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input type="radio" checked={model === 'structural'} onChange={() => setModel('structural')} />
+            Structural inference
+          </label>
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input type="radio" checked={model === 'llm'} onChange={() => setModel('llm')} />
+            LLM (Claude Sonnet)
+          </label>
+        </CardContent>
+      </Card>
+
+      {/* Document Selection */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">Documents</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="radio" checked={docMode === 'all'} onChange={() => setDocMode('all')} />
+              All fixtures ({documents.length})
+            </label>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="radio" checked={docMode === 'select'} onChange={() => setDocMode('select')} />
+              Select...
+            </label>
+            {gtSets.length > 0 && (
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input type="radio" checked={docMode === 'gt'} onChange={() => setDocMode('gt')} />
+                GT set
+              </label>
+            )}
+          </div>
+          {docMode === 'select' && (
+            <div className="flex flex-col gap-2">
+              <Input
+                placeholder="Filter documents..."
+                value={docFilter}
+                onChange={e => setDocFilter(e.target.value)}
+                className="max-w-sm"
+              />
+              <div className="border rounded-md max-h-40 overflow-y-auto p-2 flex flex-col gap-0.5">
+                {filteredDocs.slice(0, 100).map(d => (
+                  <label key={d.id} className="flex items-center gap-2 text-xs py-0.5 cursor-pointer hover:bg-muted px-1 rounded">
+                    <input
+                      type="checkbox"
+                      checked={selectedDocs.includes(d.id)}
+                      onChange={() => toggleDoc(d.id)}
+                    />
+                    <span className="truncate">{d.id}</span>
+                    <Badge variant="outline" className="text-[9px] ml-auto shrink-0">{d.gaap}</Badge>
+                  </label>
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground">{selectedDocs.length} selected</p>
+            </div>
+          )}
+          {docMode === 'gt' && (
+            <Select value={gtSetId} onValueChange={setGtSetId}>
+              <SelectTrigger className="max-w-sm">
+                <SelectValue placeholder="Select GT set..." />
+              </SelectTrigger>
+              <SelectContent>
+                {gtSets.map(s => (
+                  <SelectItem key={s.id} value={s.id}>{s.name} ({s.doc_count} docs)</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Output Destinations */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">Output Destinations</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <p className="text-xs text-muted-foreground">
+            Tags always write to table_graphs.json. Select additional outputs below.
+          </p>
+          <div className="flex items-center gap-6 flex-wrap">
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" checked={writeTagLog} onChange={e => setWriteTagLog(e.target.checked)} />
+              Tag log
+            </label>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" checked={writeVoting} onChange={e => setWriteVoting(e.target.checked)} />
+              Voting / consensus
+            </label>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Options */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">Options</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-6 flex-wrap">
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input type="checkbox" checked={dryRun} onChange={e => setDryRun(e.target.checked)} />
+            Dry run (no writes)
+          </label>
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input type="checkbox" checked={verbose} onChange={e => setVerbose(e.target.checked)} />
+            Verbose logging
+          </label>
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <div className="flex items-center gap-3 pb-4">
+        <Button variant="outline" onClick={onBack}>Cancel</Button>
+        <Button
+          onClick={handleStart}
+          disabled={createRun.isPending || (docMode === 'select' && selectedDocs.length === 0)}
+        >
+          {createRun.isPending ? (
+            <><Loader2 className="size-4 mr-1.5 animate-spin" /> Starting...</>
+          ) : (
+            <><Play className="size-4 mr-1.5" /> Start Run</>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ── Run Detail View ───────────────────────────────────────
+
+function RunDetailView({ runId, onBack }) {
+  const { data: run } = useMachineTagRun(runId)
+  const { data: results = [] } = useMachineTagRunResults(runId)
+  const cancelRun = useCancelMachineTagRun()
+
+  if (!run || run.error) {
+    return <div className="p-6 text-sm text-muted-foreground">Run not found</div>
+  }
+
+  const progress = run.progress || {}
+  const pct = progress.docs_total
+    ? Math.round((progress.docs_completed / progress.docs_total) * 100)
+    : 0
+  const summary = run.summary || {}
+
+  return (
+    <div className="flex flex-col gap-4 p-6 h-full overflow-y-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          <ArrowLeft className="size-4" />
+        </Button>
+        <h1 className="text-lg font-semibold font-mono">{run.run_id}</h1>
+        <Badge variant="outline" className="text-[10px]">
+          {MODEL_LABELS[run.config?.model] || run.config?.model}
+        </Badge>
+        <StatusBadge status={run.status} />
+        <span className="text-sm text-muted-foreground">
+          {progress.docs_completed ?? 0}/{progress.docs_total ?? '?'} docs
+        </span>
+        <span className="text-sm text-muted-foreground">
+          {formatDuration(run.started_at, run.completed_at)}
+        </span>
+        {run.status === 'running' && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="ml-auto text-destructive"
+            onClick={() => cancelRun.mutate(runId)}
+            disabled={cancelRun.isPending}
+          >
+            <Square className="size-3.5 mr-1" />
+            Cancel
+          </Button>
+        )}
+      </div>
+
+      {/* Progress bar for running */}
+      {run.status === 'running' && (
+        <Progress value={pct} className="h-2" />
+      )}
+
+      {/* Summary cards */}
+      {(run.status === 'completed' || run.status === 'failed') && summary && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {summary.docs_processed != null && (
+            <Card>
+              <CardContent className="pt-4 pb-3">
+                <p className="text-2xl font-bold">{summary.docs_processed}</p>
+                <p className="text-xs text-muted-foreground">Docs Processed</p>
+              </CardContent>
+            </Card>
+          )}
+          {summary.rows_tagged != null && (
+            <Card>
+              <CardContent className="pt-4 pb-3">
+                <p className="text-2xl font-bold">{summary.rows_tagged?.toLocaleString()}</p>
+                <p className="text-xs text-muted-foreground">Rows Tagged</p>
+              </CardContent>
+            </Card>
+          )}
+          {summary.tag_log_entries != null && (
+            <Card>
+              <CardContent className="pt-4 pb-3">
+                <p className="text-2xl font-bold">{summary.tag_log_entries?.toLocaleString()}</p>
+                <p className="text-xs text-muted-foreground">Tag Log Entries</p>
+              </CardContent>
+            </Card>
+          )}
+          {summary.votes_cast != null && (
+            <Card>
+              <CardContent className="pt-4 pb-3">
+                <p className="text-2xl font-bold">{summary.votes_cast?.toLocaleString()}</p>
+                <p className="text-xs text-muted-foreground">Votes Cast</p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {/* Config summary */}
+      {run.config && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Configuration</CardTitle>
+          </CardHeader>
+          <CardContent className="text-xs text-muted-foreground flex gap-4 flex-wrap">
+            <span>Model: <strong>{MODEL_LABELS[run.config.model] || run.config.model}</strong></span>
+            {run.config.dry_run && <Badge variant="outline" className="text-[9px]">dry run</Badge>}
+            {run.config.write_tag_log && <Badge variant="outline" className="text-[9px]">tag log</Badge>}
+            {run.config.write_voting && <Badge variant="outline" className="text-[9px]">voting</Badge>}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Per-document results */}
+      <div>
+        <h2 className="font-semibold text-sm mb-2">Per-Document Results</h2>
+        {results.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {run.status === 'running' ? 'Waiting for first document to complete...' : 'No results available'}
+          </p>
+        ) : (
+          <div className="rounded-lg border overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Document</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Rows Tagged</TableHead>
+                  <TableHead>Tag Log</TableHead>
+                  <TableHead>Votes</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {results.map(r => (
+                  <TableRow key={r.document_id}>
+                    <TableCell className="font-medium text-sm">{r.document_id}</TableCell>
+                    <TableCell>
+                      {r.error ? (
+                        <Badge variant="outline" className="text-[10px] bg-red-100 text-red-800">
+                          error
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-[10px] bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                          done
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-sm">{r.rows_tagged ?? '\u2013'}</TableCell>
+                    <TableCell className="text-sm">{r.tag_log_entries ?? '\u2013'}</TableCell>
+                    <TableCell className="text-sm">{r.votes_cast ?? '\u2013'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Main Page ─────────────────────────────────────────────
+
+export default function MachineTagPage() {
+  const [view, setView] = useState('list')
+  const [activeRunId, setActiveRunId] = useState(null)
+
+  switch (view) {
+    case 'new':
+      return (
+        <NewRunView
+          onBack={() => setView('list')}
+          onCreated={(runId) => { setActiveRunId(runId); setView('detail') }}
+        />
+      )
+    case 'detail':
+      return (
+        <RunDetailView
+          runId={activeRunId}
+          onBack={() => setView('list')}
+        />
+      )
+    default:
+      return (
+        <RunListView
+          onSelect={(runId) => { setActiveRunId(runId); setView('detail') }}
+          onNewRun={() => setView('new')}
+        />
+      )
+  }
+}

--- a/explorer/frontend/src/components/TagLogPage.jsx
+++ b/explorer/frontend/src/components/TagLogPage.jsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useState, useMemo } from 'react'
 import {
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
+  getFilteredRowModel,
   useReactTable,
 } from '@tanstack/react-table'
 import { useTagLog } from '../api.js'
@@ -12,12 +13,22 @@ import {
 import { Badge } from './ui/badge.jsx'
 import { Button } from './ui/button.jsx'
 import { Skeleton } from './ui/skeleton.jsx'
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from './ui/select.jsx'
 import { ArrowUpDown } from 'lucide-react'
 
 const ACTION_VARIANT = {
   add: 'default',
   remove: 'destructive',
   reclassify: 'secondary',
+}
+
+const SOURCE_LABELS = {
+  human: 'Human',
+  'machine:pretag': 'Pretag',
+  'machine:structural': 'Structural',
+  'machine:llm': 'LLM',
 }
 
 function SortHeader({ column, children }) {
@@ -66,7 +77,6 @@ const columns = [
         {row.original.doc_id}
       </span>
     ),
-    // No fixed width — this column fills remaining space
   },
   {
     accessorKey: 'page_no',
@@ -85,6 +95,25 @@ const columns = [
       </Badge>
     ),
     meta: { className: 'w-[90px]' },
+  },
+  {
+    accessorKey: 'source',
+    header: 'Source',
+    cell: ({ row }) => {
+      const src = row.original.source || 'human'
+      const label = SOURCE_LABELS[src] || src
+      const isMachine = src.startsWith('machine:')
+      return (
+        <Badge variant={isMachine ? 'secondary' : 'outline'} className="text-[10px]">
+          {label}
+        </Badge>
+      )
+    },
+    meta: { className: 'w-[100px]' },
+    filterFn: (row, _columnId, filterValue) => {
+      if (!filterValue || filterValue === 'all') return true
+      return (row.original.source || 'human') === filterValue
+    },
   },
   {
     accessorKey: 'element_type',
@@ -108,16 +137,29 @@ const columns = [
 
 export default function TagLogPage() {
   const { data: entries = [], isLoading } = useTagLog()
+  const [sourceFilter, setSourceFilter] = useState('all')
 
   const table = useReactTable({
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    state: {
+      columnFilters: sourceFilter !== 'all'
+        ? [{ id: 'source', value: sourceFilter }]
+        : [],
+    },
     initialState: {
       sorting: [{ id: 'timestamp', desc: true }],
     },
   })
+
+  // Collect unique sources for the filter dropdown
+  const availableSources = useMemo(() => {
+    const sources = new Set(entries.map(e => e.source || 'human'))
+    return [...sources].sort()
+  }, [entries])
 
   if (isLoading) {
     return (
@@ -131,13 +173,34 @@ export default function TagLogPage() {
     )
   }
 
+  const filteredCount = table.getFilteredRowModel().rows.length
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden px-4 lg:px-6 py-6 md:py-8 gap-4">
-      <div>
-        <h1 className="text-xl font-semibold">Tag Log</h1>
-        <p className="text-sm text-muted-foreground">
-          {entries.length} tagging action{entries.length !== 1 ? 's' : ''} recorded.
-        </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Tag Log</h1>
+          <p className="text-sm text-muted-foreground">
+            {filteredCount} tagging action{filteredCount !== 1 ? 's' : ''}
+            {sourceFilter !== 'all' ? ` (filtered)` : ''} recorded.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">Source:</span>
+          <Select value={sourceFilter} onValueChange={setSourceFilter}>
+            <SelectTrigger className="w-36 h-8">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All sources</SelectItem>
+              {availableSources.map(src => (
+                <SelectItem key={src} value={src}>
+                  {SOURCE_LABELS[src] || src}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
       <div className="rounded-lg border overflow-auto flex-1">
         <Table className="table-fixed">

--- a/explorer/server.py
+++ b/explorer/server.py
@@ -1560,6 +1560,7 @@ async def append_tag_log(request: Request):
         "action": body.get("action"),
         "element_type": body.get("element_type"),
         "old_type": body.get("old_type"),
+        "source": body.get("source", "human"),
     }
     if USE_SUPABASE:
         try:
@@ -3415,6 +3416,200 @@ async def api_cancel_run(run_id: str, request: Request):
             run["status"] = "cancelled"
             run["completed_at"] = datetime.utcnow().isoformat()
             _save_runs_index(runs)
+            return {"status": "cancelled"}
+    return {"error": "run not found"}
+
+
+# ── Machine Tag Runs ──────────────────────────────────────
+_MT_RUNS_DIR = REPO_ROOT / "eval" / "machine_tag_runs"
+_MT_RUNS_STATE_PATH = _MT_RUNS_DIR / ".mt_runs_index.json"
+_mt_active_processes: dict[str, "subprocess.Popen"] = {}
+
+
+def _load_mt_runs_index() -> list[dict]:
+    if _MT_RUNS_STATE_PATH.exists():
+        with open(_MT_RUNS_STATE_PATH) as f:
+            return json.load(f)
+    return []
+
+
+def _save_mt_runs_index(runs: list[dict]):
+    _MT_RUNS_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(_MT_RUNS_STATE_PATH, "w") as f:
+        json.dump(runs, f, indent=2, default=str)
+
+
+def _make_mt_run_id() -> str:
+    now = datetime.utcnow()
+    runs = _load_mt_runs_index()
+    today = now.strftime("%d%m%Y")
+    today_count = sum(1 for r in runs if r.get("run_id", "").startswith(today + "MT"))
+    return f"{today}MT{today_count + 1:03d}"
+
+
+def _read_mt_run_summary(run_id: str) -> dict | None:
+    summary_path = _MT_RUNS_DIR / run_id / "summary.json"
+    if summary_path.exists():
+        with open(summary_path) as f:
+            return json.load(f)
+    return None
+
+
+def _read_mt_run_results(run_id: str) -> list[dict]:
+    """Read per-document result.json files from a machine tag run directory."""
+    run_dir = _MT_RUNS_DIR / run_id
+    if not run_dir.exists():
+        return []
+    results = []
+    for doc_dir in sorted(run_dir.iterdir()):
+        if not doc_dir.is_dir() or doc_dir.name.startswith("."):
+            continue
+        result_json = doc_dir / "result.json"
+        if result_json.exists():
+            with open(result_json) as f:
+                results.append(json.load(f))
+    return results
+
+
+def _update_mt_run_progress(run_id: str):
+    """Update a machine tag run's progress from its output directory."""
+    runs = _load_mt_runs_index()
+    for run in runs:
+        if run["run_id"] == run_id:
+            results = _read_mt_run_results(run_id)
+            docs_completed = len(results)
+            docs_total = len(run.get("config", {}).get("documents", []))
+            run["progress"] = {
+                "docs_completed": docs_completed,
+                "docs_total": docs_total,
+            }
+            proc = _mt_active_processes.get(run_id)
+            if proc:
+                poll = proc.poll()
+                if poll is not None:
+                    del _mt_active_processes[run_id]
+                    summary = _read_mt_run_summary(run_id)
+                    run["status"] = "completed" if poll == 0 else "failed"
+                    run["completed_at"] = datetime.utcnow().isoformat()
+                    if summary:
+                        run["summary"] = summary
+            _save_mt_runs_index(runs)
+            return run
+    return None
+
+
+@app.get("/api/machine-tag/runs")
+def api_list_mt_runs():
+    """List all machine tag runs."""
+    runs = _load_mt_runs_index()
+    for run in runs:
+        if run.get("status") == "running":
+            _update_mt_run_progress(run["run_id"])
+    runs = _load_mt_runs_index()
+    return {"runs": runs}
+
+
+@app.get("/api/machine-tag/runs/{run_id}")
+def api_get_mt_run(run_id: str):
+    """Get a single machine tag run with progress."""
+    runs = _load_mt_runs_index()
+    for run in runs:
+        if run["run_id"] == run_id:
+            if run.get("status") == "running":
+                _update_mt_run_progress(run_id)
+                runs = _load_mt_runs_index()
+                for r in runs:
+                    if r["run_id"] == run_id:
+                        return r
+            return run
+    return {"error": "run not found"}
+
+
+@app.get("/api/machine-tag/runs/{run_id}/results")
+def api_get_mt_run_results(run_id: str):
+    """Get per-document results for a machine tag run."""
+    results = _read_mt_run_results(run_id)
+    return {"results": results}
+
+
+@app.post("/api/machine-tag/runs")
+async def api_create_mt_run(request: Request):
+    """Create and start a new machine tag run."""
+    import subprocess
+    user = _require_auth(request)
+    body = await request.json()
+
+    run_id = _make_mt_run_id()
+    model = body.get("model", "pretag")
+    documents = body.get("documents", [])
+    config = body.get("config", {})
+
+    cmd = [
+        sys.executable, str(REPO_ROOT / "eval" / "machine_tag_runner.py"),
+        "--model", model,
+        "--documents", *documents,
+        "--output-dir", str(_MT_RUNS_DIR / run_id),
+    ]
+    if config.get("dry_run"):
+        cmd.append("--dry-run")
+    if config.get("verbose"):
+        cmd.append("--verbose")
+    if config.get("write_tag_log"):
+        cmd.append("--write-tag-log")
+    if config.get("write_voting"):
+        cmd.append("--write-voting")
+
+    run_entry = {
+        "run_id": run_id,
+        "status": "running",
+        "created_by": str(user.id),
+        "config": {
+            "model": model,
+            "documents": documents,
+            "dry_run": config.get("dry_run", False),
+            "verbose": config.get("verbose", False),
+            "write_tag_log": config.get("write_tag_log", False),
+            "write_voting": config.get("write_voting", False),
+        },
+        "progress": {"docs_completed": 0, "docs_total": len(documents)},
+        "started_at": datetime.utcnow().isoformat(),
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    runs = _load_mt_runs_index()
+    runs.insert(0, run_entry)
+    _save_mt_runs_index(runs)
+
+    (_MT_RUNS_DIR / run_id).mkdir(parents=True, exist_ok=True)
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(REPO_ROOT),
+        stdout=open(_MT_RUNS_DIR / run_id / "stdout.log", "w"),
+        stderr=subprocess.STDOUT,
+    )
+    _mt_active_processes[run_id] = proc
+
+    return {"run": run_entry}
+
+
+@app.post("/api/machine-tag/runs/{run_id}/cancel")
+async def api_cancel_mt_run(run_id: str, request: Request):
+    """Cancel a running machine tag run."""
+    _require_auth(request)
+    proc = _mt_active_processes.get(run_id)
+    if proc:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+        del _mt_active_processes[run_id]
+
+    runs = _load_mt_runs_index()
+    for run in runs:
+        if run["run_id"] == run_id:
+            run["status"] = "cancelled"
+            run["completed_at"] = datetime.utcnow().isoformat()
+            _save_mt_runs_index(runs)
             return {"status": "cancelled"}
     return {"error": "run not found"}
 


### PR DESCRIPTION
## Summary
- New **Machine Tag** page under Pipeline sidebar for running individual tagging models (pretag, structural, LLM) against selected datasets
- List/new/detail sub-view pattern matching TrainingPage, with model selection, dataset picker (all/select/GT set), and output destination checkboxes (tag log + voting)
- Backend `eval/machine_tag_runner.py` subprocess + `/api/machine-tag/runs` endpoints with separate run index
- Tag Log page gains a **source** column and filter dropdown to distinguish `human` vs `machine:pretag|structural|llm` entries
- Voting integration calls `queries.cast_tag_vote()` directly from Python (no HTTP auth needed)

Closes #51

## Test plan
- [ ] Navigate to Pipeline > Machine Tag in sidebar
- [ ] Create a pretag run against a single fixture (e.g. amag_2024) with tag log enabled
- [ ] Verify run appears in list, transitions through running → completed
- [ ] Check detail view shows per-document results with rows_tagged count
- [ ] Verify tag log entries appear in Tag Log page with `source: machine:pretag`
- [ ] Test source filter dropdown filters correctly
- [ ] Test cancel button on a running LLM run
- [ ] Verify dry-run mode produces no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)